### PR TITLE
fix: Log when files not found

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,10 @@ export interface DotenvCraOptions extends DotenvConfigOptions {
 }
 
 export function config(options?: DotenvCraOptions): DotenvConfigOutput {
+  const log = (message: string): void => {
+    options?.debug && console.log(`[dotenv-cra][DEBUG] ${message}`);
+  };
+
   // Reference:
   // https://github.com/facebook/create-react-app/blob/8b7b819b4b9e6ba457e011e92e33266690e26957/packages/react-scripts/config/env.js#L18-L23
   if (!process.env.NODE_ENV) {
@@ -40,30 +44,31 @@ export function config(options?: DotenvCraOptions): DotenvConfigOutput {
   // https://github.com/facebook/create-react-app/blob/8b7b819b4b9e6ba457e011e92e33266690e26957/packages/react-scripts/config/env.js#L36-L49
   let parsed: { [name: string]: string } = {};
   for (const dotenvFile of dotenvFiles) {
-    if (dotenvFile && existsSync(dotenvFile)) {
-      if (options?.debug) {
-        log(`loading \`${basename(dotenvFile)}\``);
-      }
-
-      const result = dotenvExpand(
-        dotenvConfig({
-          debug: options?.debug,
-          encoding: options?.encoding,
-          path: dotenvFile,
-        }),
-      );
-
-      if (result.error) {
-        return result;
-      }
-      parsed = { ...result.parsed, ...parsed };
+    if (!dotenvFile) {
+      continue;
     }
+    if (!existsSync(dotenvFile)) {
+      log(`\`${basename(dotenvFile)}\` file not found`);
+      continue;
+    }
+
+    log(`loading \`${basename(dotenvFile)}\``);
+
+    const result = dotenvExpand(
+      dotenvConfig({
+        debug: options?.debug,
+        encoding: options?.encoding,
+        path: dotenvFile,
+      }),
+    );
+
+    if (result.error) {
+      return result;
+    }
+    parsed = { ...result.parsed, ...parsed };
   }
+
   return {
     parsed,
   };
-}
-
-function log(message: string): void {
-  console.log(`[dotenv-cra][DEBUG] ${message}`);
 }

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -68,16 +68,20 @@ test('should allow custom .env path when `path` supplied in options', () => {
   expect(firstCallPath?.startsWith('/foo/bar/')).toEqual(true);
 });
 
-test('should log files loaded when `debug` supplied in options', () => {
+test('should log files loaded and file that do not exist when `debug` supplied in options', () => {
   process.env.NODE_ENV = 'development';
-  jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+  jest
+    .spyOn(fs, 'existsSync')
+    .mockImplementation(
+      (path) => !path.toString().endsWith('.env.development.local'),
+    );
   jest.spyOn(dotenv, 'config').mockImplementation(makeMockDotenvConfig());
   const consoleLogSpy = jest.spyOn(console, 'log');
 
   config({ debug: true });
   expect(consoleLogSpy).toBeCalledTimes(4);
   expect(consoleLogSpy.mock.calls[0][0]).toEqual(
-    '[dotenv-cra][DEBUG] loading `.env.development.local`',
+    '[dotenv-cra][DEBUG] `.env.development.local` file not found',
   );
   expect(consoleLogSpy.mock.calls[1][0]).toEqual(
     '[dotenv-cra][DEBUG] loading `.env.local`',


### PR DESCRIPTION
When the `debug` option is enabled and a `.env*` file can't be found `console.log()`.